### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,5 +1,8 @@
 name: Jekyll site CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/pbsabella/pbsabella.github.io/security/code-scanning/1](https://github.com/pbsabella/pbsabella.github.io/security/code-scanning/1)

To fix the problem, explicitly define a `permissions` block that restricts the `GITHUB_TOKEN` to the least privilege necessary. For this job, all steps only read the repository contents and run local commands, so `contents: read` is sufficient. This can be defined at the workflow root (applies to all jobs without their own `permissions`) or at the job level. The smallest, least intrusive change is to add a root-level `permissions` section just after the `name` (or just before `on:`) in `.github/workflows/jekyll.yml`.

Concretely, in `.github/workflows/jekyll.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file. No existing steps need to be modified, and no imports or additional methods are required. This change preserves existing functionality while ensuring the `GITHUB_TOKEN` cannot be used to modify repository contents or perform unnecessary write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
