### PR TITLE
refactor(ui): restrict custom className overrides for design system consistency

### DIFF
--- a/src/components/sections/Contact.module.css
+++ b/src/components/sections/Contact.module.css
@@ -26,7 +26,3 @@
   align-items: center;
   gap: var(--pr-spacing-3);
 }
-
-.contactSocials {
-  margin-top: 0;
-}

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -17,12 +17,11 @@ const Contact = () => {
         <div className={styles.contactActions}>
           <Button
             as="a"
-            className={styles.contactEmailLink}
             href="mailto:pau.abella@gmail.com"
           >
             Email
           </Button>
-          <Socials className={styles.contactSocials} />
+          <Socials />
         </div>
       </div>
     </FeaturedSection>

--- a/src/components/sections/WorkItem.tsx
+++ b/src/components/sections/WorkItem.tsx
@@ -77,44 +77,45 @@ const WorkItem = ({
         <Card
           as="article"
           variant="panel"
-          className={panelClassNames}
           data-tone={tone}
           data-media-side={mediaSide}
           data-media-preset={mediaPreset}
         >
-          <div className={mediaClassNames}>
-            <img
-              className={imageClassNames}
-              src={image}
-              alt={imageAlt ?? `${title} project preview`}
-              width="1440"
-              height="810"
-              loading="lazy"
-            />
-          </div>
-
-          <div className={styles.workItemBody}>
-            <div className={styles.workItemSubtitle}>
-              <span className={styles.workItemCompany}>{company}</span>
-              {period && <time className={styles.workItemPeriod}>{period}</time>}
+          <div className={panelClassNames}>
+            <div className={mediaClassNames}>
+              <img
+                className={imageClassNames}
+                src={image}
+                alt={imageAlt ?? `${title} project preview`}
+                width="1440"
+                height="810"
+                loading="lazy"
+              />
             </div>
 
-            <h4 className={`h3 ${styles.workItemTitle}`}>{title}</h4>
-            <p className={styles.workItemPosition}>{position}</p>
+            <div className={styles.workItemBody}>
+              <div className={styles.workItemSubtitle}>
+                <span className={styles.workItemCompany}>{company}</span>
+                {period && <time className={styles.workItemPeriod}>{period}</time>}
+              </div>
 
-            <div className={styles.workItemDescription}>
-              {description.map((desc) => (
-                <p key={desc}>{desc}</p>
-              ))}
+              <h4 className={`h3 ${styles.workItemTitle}`}>{title}</h4>
+              <p className={styles.workItemPosition}>{position}</p>
+
+              <div className={styles.workItemDescription}>
+                {description.map((desc) => (
+                  <p key={desc}>{desc}</p>
+                ))}
+              </div>
+
+              <ul className={styles.workItemTags} aria-label="Project technologies">
+                {tags.map((tag) => (
+                  <li key={tag} className={styles.workItemTagItem}>
+                    <Tag>{tag}</Tag>
+                  </li>
+                ))}
+              </ul>
             </div>
-
-            <ul className={styles.workItemTags} aria-label="Project technologies">
-              {tags.map((tag) => (
-                <li key={tag} className={styles.workItemTagItem}>
-                  <Tag>{tag}</Tag>
-                </li>
-              ))}
-            </ul>
           </div>
         </Card>
       </Container>

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -19,14 +19,13 @@ const variantIconMap: Partial<Record<AlertVariant, LucideIcon>> = {
   error: CircleAlert,
 };
 
-interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title' | 'className'> {
   /** Main alert content */
   children: ReactNode;
   /** Optional heading shown above body content */
   title?: ReactNode;
   /** Semantic intent variant */
   variant?: AlertVariant;
-  className?: string;
 }
 
 /**
@@ -49,7 +48,6 @@ const Alert = ({
   children,
   title,
   variant = 'default',
-  className,
   ...props
 }: AlertProps) => {
   const titleId = useId();
@@ -57,7 +55,7 @@ const Alert = ({
   const ariaLive = props['aria-live'] ?? (role === 'alert' ? 'assertive' : 'polite');
   const ariaAtomic = props['aria-atomic'] ?? 'true';
 
-  const classNames = [styles.alert, variantMap[variant], className]
+  const classNames = [styles.alert, variantMap[variant]]
     .filter(Boolean)
     .join(' ');
 

--- a/src/components/ui/Badge/Badge.test.tsx
+++ b/src/components/ui/Badge/Badge.test.tsx
@@ -43,9 +43,4 @@ describe('Badge Component', () => {
     expect(badge).toHaveAttribute('aria-label', '3 unread notifications');
     expect(badge).not.toHaveAttribute('aria-hidden');
   });
-
-  it('merges custom className', () => {
-    render(<Badge className="custom-badge">5</Badge>);
-    expect(screen.getByText('5')).toHaveClass('custom-badge');
-  });
 });

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -17,14 +17,13 @@ const sizeMap: Record<BadgeSize, string> = {
   lg: styles.badgeLg,
 };
 
-interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+interface BadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'className'> {
   /** Content to display inside the badge, usually a number or short label */
   children?: ReactNode; // optional for sm size dots
   /** Visual variant that determines background and text colors */
   variant?: BadgeVariant;
   /** Size of the badge; affects font-size, padding, and border-radius */
   size?: BadgeSize;
-  className?: string;
 }
 
 /**
@@ -60,14 +59,12 @@ const Badge = ({
   size = 'md',
   'aria-label': ariaLabel,
   role,
-  className,
   ...props
 }: BadgeProps) => {
   const classNames = [
     styles.badge,
     variantMap[variant],
     sizeMap[size],
-    className,
   ].filter(Boolean).join(' ');
 
   const ariaHidden = size === 'sm' && !ariaLabel ? true : undefined;

--- a/src/components/ui/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/ui/Breadcrumbs/Breadcrumbs.tsx
@@ -9,10 +9,9 @@ export type BreadcrumbItem = {
   to?: string;
 };
 
-interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
+interface BreadcrumbsProps extends Omit<HTMLAttributes<HTMLElement>, 'className'> {
   /** Ordered breadcrumb trail */
   items: BreadcrumbItem[];
-  className?: string;
 }
 
 /**
@@ -30,9 +29,8 @@ interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
  * - Uses `nav` landmark with default `aria-label="Breadcrumb"`.
  * - Last item is marked with `aria-current="page"`.
  */
-const Breadcrumbs = ({ items, className, ...props }: BreadcrumbsProps) => {
+const Breadcrumbs = ({ items, ...props }: BreadcrumbsProps) => {
   const { 'aria-label': ariaLabel = 'Breadcrumb', ...restProps } = props;
-  const classNames = [styles.breadcrumbs, className].filter(Boolean).join(' ');
 
   if (items.length === 0) {
     return null;
@@ -40,7 +38,7 @@ const Breadcrumbs = ({ items, className, ...props }: BreadcrumbsProps) => {
 
   return (
     <nav
-      className={classNames}
+      className={styles.breadcrumbs}
       aria-label={ariaLabel}
       {...restProps}
     >

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -22,11 +22,10 @@ type ButtonOwnProps<T extends ElementType> = {
   variant?: ButtonVariant;
   /** Size token mapping */
   size?: ButtonSize;
-  className?: string;
 };
 
 type ButtonProps<T extends ElementType> = ButtonOwnProps<T> &
-  Omit<ComponentPropsWithoutRef<T>, keyof ButtonOwnProps<T>>;
+  Omit<ComponentPropsWithoutRef<T>, keyof ButtonOwnProps<T> | 'className'>;
 
 /**
  * Button Component
@@ -48,7 +47,6 @@ const Button = <T extends ElementType = 'button'>({
   children,
   variant = 'primary',
   size = 'md',
-  className,
   ...props
 }: ButtonProps<T>) => {
   const Component = as || 'button';
@@ -57,7 +55,6 @@ const Button = <T extends ElementType = 'button'>({
     styles.button,
     variantMap[variant],
     sizeMap[size],
-    className
   ].filter(Boolean).join(' ');
 
   const isNativeButton = Component === 'button';

--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -15,15 +15,13 @@ const toneMap: Record<CardTone, string> = {
   dashed: styles.cardToneDashed,
 };
 
-interface CardProps extends HTMLAttributes<HTMLDivElement> {
+interface CardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'className'> {
   /** The visual style of the card */
   variant?: CardVariant;
   /** Optional tone treatment applied on top of the variant */
   tone?: CardTone;
   /** Card content */
   children: ReactNode;
-  /** Optional additional CSS class */
-  className?: string;
   /** Enables hover affordance styles */
   isInteractive?: boolean;
   /** Underlying element type for semantic wrappers */
@@ -48,7 +46,6 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
  */
 const Card = ({
   children,
-  className,
   variant = 'elevated',
   tone = 'default',
   isInteractive = false,
@@ -60,7 +57,6 @@ const Card = ({
     variantMap[variant],
     toneMap[tone],
     isInteractive && styles.cardInteractive,
-    className
   ].filter(Boolean).join(' ');
 
   return (

--- a/src/components/ui/Socials/Socials.test.tsx
+++ b/src/components/ui/Socials/Socials.test.tsx
@@ -17,10 +17,9 @@ describe('Socials', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('merges custom className and supports aria-label override', () => {
-    render(<Socials className="custom-socials" aria-label="Contact links" />);
+  it('merges supports aria-label override', () => {
+    render(<Socials aria-label="Contact links" />);
 
-    const list = screen.getByRole('list', { name: 'Contact links' });
-    expect(list).toHaveClass('custom-socials');
+    expect(screen.getByRole('list', { name: 'Contact links' })).toBeVisible();
   });
 });

--- a/src/components/ui/Socials/Socials.tsx
+++ b/src/components/ui/Socials/Socials.tsx
@@ -16,13 +16,11 @@ import styles from './Socials.module.css';
  * - External links include descriptive `title`.
  * - Links open in a new tab with `rel="noopener noreferrer"`.
  */
-
-const Socials = ({ className, ...props }: HTMLAttributes<HTMLUListElement>) => {
+const Socials = ({ ...props }: Omit<HTMLAttributes<HTMLUListElement>, 'className'>) => {
   const { 'aria-label': ariaLabel = 'Social links', ...restProps } = props;
-  const classNames = [styles.socials, className].filter(Boolean).join(' ');
 
   return (
-    <ul className={classNames} aria-label={ariaLabel} {...restProps}>
+    <ul className={styles.socials} aria-label={ariaLabel} {...restProps}>
       <li className={styles.socialsItem}>
         <a
           className={`${styles.socialsLink} link`}

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -13,8 +13,7 @@ const variantMap: Record<TableVariant, string> = {
   compact: styles.tableCompact,
   striped: styles.tableStriped,
 };
-
-interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
+interface TableProps extends Omit<TableHTMLAttributes<HTMLTableElement>, 'className'> {
   /** Optional visible caption (preferred for accessibility) */
   caption?: string;
   /** Column definitions used for headers and stacked labels */
@@ -27,7 +26,6 @@ interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
   variant?: TableVariant;
   /** Enables mobile stacked row layout */
   stacked?: boolean;
-  className?: string;
 }
 
 /**
@@ -51,14 +49,12 @@ const Table = ({
   label,
   variant = 'default',
   stacked = true,
-  className,
   ...props
 }: TableProps) => {
   const classNames = [
     styles.table,
     variantMap[variant],
     stacked ? styles.tableStacked : '',
-    className
   ].filter(Boolean).join(' ');
 
   const ariaLabel = caption ? undefined : label ?? props['aria-label'];

--- a/src/components/ui/TableOfContents/TableOfContents.tsx
+++ b/src/components/ui/TableOfContents/TableOfContents.tsx
@@ -9,7 +9,7 @@ export type TableOfContentsSection = {
   label: string;
 };
 
-interface TableOfContentsProps extends HTMLAttributes<HTMLElement> {
+interface TableOfContentsProps extends Omit<HTMLAttributes<HTMLElement>, 'className'> {
   /** Ordered section anchors to render */
   sections: TableOfContentsSection[];
   /** Activation offset for scroll spy calculations */
@@ -20,7 +20,6 @@ interface TableOfContentsProps extends HTMLAttributes<HTMLElement> {
   respectReducedMotion?: boolean;
   /** Keeps TOC sticky when true */
   isSticky?: boolean;
-  className?: string;
 }
 
 /**
@@ -43,14 +42,12 @@ const TableOfContents = ({
   scrollBehavior = 'instant',
   respectReducedMotion = true,
   isSticky = true,
-  className,
   ...props
 }: TableOfContentsProps) => {
   const { 'aria-label': ariaLabel = 'Table of contents', ...restProps } = props;
   const classNames = [
     styles.tableOfContents,
     !isSticky && styles.tableOfContentsStatic,
-    className,
   ].filter(Boolean).join(' ');
 
   const scrollToSection = useScrollToSection();

--- a/src/components/ui/Tag/Tag.test.tsx
+++ b/src/components/ui/Tag/Tag.test.tsx
@@ -20,14 +20,13 @@ describe('Tag Component', () => {
     expect(tag.className).toMatch(/tagSm/);
   });
 
-  it('merges custom className and forwards native attributes', () => {
+  it('forwards native attributes', () => {
     render(
-      <Tag className="custom-tag" title="Tag title" data-testid="tag">
+      <Tag title="Tag title" data-testid="tag">
         CSS
       </Tag>,
     );
     const tag = screen.getByTestId('tag');
-    expect(tag).toHaveClass('custom-tag');
     expect(tag).toHaveAttribute('title', 'Tag title');
   });
 });

--- a/src/components/ui/Tag/Tag.tsx
+++ b/src/components/ui/Tag/Tag.tsx
@@ -18,14 +18,13 @@ const sizeMap: Record<TagSize, string> = {
   lg: styles.tagLg,
 };
 
-interface TagProps extends HTMLAttributes<HTMLSpanElement> {
+interface TagProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'className'> {
   /** Content to display inside the tag */
   children: ReactNode;
   /** Visual variant that determines color scheme */
   variant?: TagVariant;
   /** Size of the tag, affects font-size and padding */
   size?: TagSize;
-  className?: string;
 }
 
 /**
@@ -58,14 +57,12 @@ const Tag = ({
   children,
   variant = 'default',
   size = 'md',
-  className,
   ...props
 }: TagProps) => {
   const classNames = [
     styles.tag,
     variantMap[variant],
     sizeMap[size],
-    className,
   ].filter(Boolean).join(' ');
 
   return (

--- a/src/components/ui/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle/ThemeToggle.tsx
@@ -11,7 +11,6 @@ interface ThemeToggleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'icon' | 'text';
   /** Optional accessible text override */
   label?: string;
-  className?: string;
 }
 
 /**
@@ -30,7 +29,13 @@ interface ThemeToggleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * - Uses an action-oriented label (`Switch to {nextTheme} mode`) for both icon and text variants
  * - Exposes `aria-pressed` to reflect current theme state
  */
-const ThemeToggle = ({ id, variant = 'icon', label, className, onClick, ...props }: ThemeToggleProps) => {
+const ThemeToggle = ({
+  id,
+  variant = 'icon',
+  label,
+  onClick,
+  ...props
+}: ThemeToggleProps) => {
   const { theme, toggleTheme } = useTheme();
   const [hasInteracted, setHasInteracted] = useState(false);
   const isDarkTheme = theme === 'dark';
@@ -52,7 +57,6 @@ const ThemeToggle = ({ id, variant = 'icon', label, className, onClick, ...props
   const iconClassNames = [
     styles.themeToggleButton,
     styles.themeToggleButtonIcon,
-    className,
   ].filter(Boolean).join(' ');
 
   return (
@@ -64,7 +68,6 @@ const ThemeToggle = ({ id, variant = 'icon', label, className, onClick, ...props
         onClick={handleClick}
         aria-label={buttonLabel}
         aria-pressed={isDarkTheme}
-        className={className}
         {...props}
       >
         {buttonLabel}

--- a/src/pages/design-system-build-notes/BuildNotesSections.tsx
+++ b/src/pages/design-system-build-notes/BuildNotesSections.tsx
@@ -120,53 +120,59 @@ export const ApproachSection = () => (
       components stay stable as themes and brands evolve.
     </p>
     <div className={styles.layerGrid}>
-      <Card variant="flat" className={styles.layerCard}>
-        <div className={styles.layerHeader}>
-          <span className={styles.layerIcon} aria-hidden="true">
-            <Palette size={24} className={styles.iconAccent} />
-          </span>
+      <Card variant="flat">
+        <div className={styles.layerCard}>
+          <div className={styles.layerHeader}>
+            <span className={styles.layerIcon} aria-hidden="true">
+              <Palette size={24} className={styles.iconAccent} />
+            </span>
+          </div>
+          <h3 className={styles.layerTitle}>Primitive</h3>
+          <p>Raw values that define the palette, scale, and motion.</p>
+          <p className={styles.layerToken}>
+            <code>--pr-[category]-[scale]</code>
+            <span className={styles.layerTokenExample}>
+              <span>e.g.</span>
+              <code>--pr-color-neutral-800</code>
+            </span>
+          </p>
         </div>
-        <h3 className={styles.layerTitle}>Primitive</h3>
-        <p>Raw values that define the palette, scale, and motion.</p>
-        <p className={styles.layerToken}>
-          <code>--pr-[category]-[scale]</code>
-          <span className={styles.layerTokenExample}>
-            <span>e.g.</span>
-            <code>--pr-color-neutral-800</code>
-          </span>
-        </p>
       </Card>
-      <Card variant="flat" className={styles.layerCard}>
-        <div className={styles.layerHeader}>
-          <span className={styles.layerIcon} aria-hidden="true">
-            <Group size={24} className={styles.iconAccent} />
-          </span>
+      <Card variant="flat">
+        <div className={styles.layerCard}>
+          <div className={styles.layerHeader}>
+            <span className={styles.layerIcon} aria-hidden="true">
+              <Group size={24} className={styles.iconAccent} />
+            </span>
+          </div>
+          <h3 className={styles.layerTitle}>Semantic</h3>
+          <p>Intent-based aliases that describe how UI should behave.</p>
+          <p className={styles.layerToken}>
+            <code>--sem-[domain]-[property]-[role]</code>
+            <span className={styles.layerTokenExample}>
+              <span>e.g.</span>
+              <code>--sem-color-text-primary</code>
+            </span>
+          </p>
         </div>
-        <h3 className={styles.layerTitle}>Semantic</h3>
-        <p>Intent-based aliases that describe how UI should behave.</p>
-        <p className={styles.layerToken}>
-          <code>--sem-[domain]-[property]-[role]</code>
-          <span className={styles.layerTokenExample}>
-            <span>e.g.</span>
-            <code>--sem-color-text-primary</code>
-          </span>
-        </p>
       </Card>
-      <Card variant="flat" className={styles.layerCard}>
-        <div className={styles.layerHeader}>
-          <span className={styles.layerIcon} aria-hidden="true">
-            <Component size={24} className={styles.iconAccent} />
-          </span>
+      <Card variant="flat">
+        <div className={styles.layerCard}>
+          <div className={styles.layerHeader}>
+            <span className={styles.layerIcon} aria-hidden="true">
+              <Component size={24} className={styles.iconAccent} />
+            </span>
+          </div>
+          <h3 className={styles.layerTitle}>Component</h3>
+          <p>Component-level tokens that bind styles to real UI pieces.</p>
+          <p className={styles.layerToken}>
+            <code>--comp-[component]-[property]</code>
+            <span className={styles.layerTokenExample}>
+              <span>e.g.</span>
+              <code>--comp-card-border</code>
+            </span>
+          </p>
         </div>
-        <h3 className={styles.layerTitle}>Component</h3>
-        <p>Component-level tokens that bind styles to real UI pieces.</p>
-        <p className={styles.layerToken}>
-          <code>--comp-[component]-[property]</code>
-          <span className={styles.layerTokenExample}>
-            <span>e.g.</span>
-            <code>--comp-card-border</code>
-          </span>
-        </p>
       </Card>
     </div>
     <Alert
@@ -269,7 +275,7 @@ export const DemoSection = () => {
   return (
     <BuildNotesBlock id="demo" kicker="07. Demo" title="The portfolio is the proof" className={styles.sectionRhythm16}>
       <figure>
-        <Card variant="panel" className={styles.demoCard}>
+        <Card variant="panel">
           <div className={styles.demoHeader}>
             <div className={styles.demoDots}>
               <span className={`${styles.demoDot} ${styles.dotError}`} />


### PR DESCRIPTION
## Summary
This change removes `className` support from core UI components to ensure strict adherence to design system specifications. By omitting this attribute from component interfaces, we prevent unauthorized style overrides and maintain visual integrity across the application.

### Key Changes
* **Type Restrictions**: Implemented `Omit<HTMLAttributes, 'className'>` across UI interfaces.
* **Prop Cleanup**: Removed `className` from destructuring and internal logic.
* **Consistency**: Guaranteed that components cannot be modified via external CSS leakage.

### Testing
* Percy: https://percy.io/c9665ed5/web/pbsabella-portfolio-875b6387/builds/46985814/
  * No diffs