### PR TITLE
feat: add scroll-lock to brand-theme-toggle when used inside a page

### DIFF
--- a/src/components/ui/BrandThemeToggle/BrandThemeToggle.module.css
+++ b/src/components/ui/BrandThemeToggle/BrandThemeToggle.module.css
@@ -113,6 +113,7 @@
   border-radius: var(--comp-btt-dropdown-radius);
   box-shadow: var(--comp-btt-dropdown-shadow);
   min-width: 192px;
+  overflow-y: auto;
   padding: var(--pr-spacing-4) var(--pr-spacing-2);
   position: fixed;
   z-index: var(--sem-z-overlay);

--- a/src/components/ui/BrandThemeToggle/BrandThemeToggle.tsx
+++ b/src/components/ui/BrandThemeToggle/BrandThemeToggle.tsx
@@ -1,10 +1,12 @@
 import { CircleCheck, Moon, Sun } from 'lucide-react';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useBrand } from '@/context/BrandContext';
 import { useTheme } from '@context/ThemeContext';
 import { BRAND_PRESETS } from '@/content/themingBuildNotes';
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useFloatingPosition } from '@/hooks/useFloatingPosition';
 import styles from './BrandThemeToggle.module.css';
 
 interface BrandThemeToggleProps {
@@ -19,45 +21,14 @@ const BrandThemeToggle = ({ id, lockScroll = false }: BrandThemeToggleProps) => 
   const { theme, toggleTheme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const [hasInteracted, setHasInteracted] = useState(false);
-  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const currentPreset = BRAND_PRESETS.find((p) => p.id === brand) ?? BRAND_PRESETS[0];
-  const BrandIcon = currentPreset.icon;
-  const isDark = theme === 'dark';
-
-  const updatePos = useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setDropdownPos({
-      top: rect.bottom + 8,
-      right: window.innerWidth - rect.right,
-    });
-  }, []);
-
-  useLayoutEffect(() => {
-    if (isOpen) updatePos();
-  }, [isOpen, updatePos]);
-
-  const handleEscape = useCallback(() => setIsOpen(false), []);
-  useFocusTrap(dropdownRef, { isActive: isOpen, onEscape: handleEscape });
+  const { triggerRef, dropdownPos } = useFloatingPosition<HTMLButtonElement>(isOpen);
+  useFocusTrap(dropdownRef, { isActive: isOpen, onEscape: useCallback(() => setIsOpen(false), []) });
+  useBodyScrollLock(isOpen && lockScroll);
 
   useEffect(() => {
-    if (!lockScroll) return;
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen, lockScroll]);
-
-  useEffect(() => {
-    if (!isOpen) return undefined;
-
+    if (!isOpen) return;
     const handleMouseDown = (e: MouseEvent) => {
       if (
         !dropdownRef.current?.contains(e.target as Node) &&
@@ -66,17 +37,13 @@ const BrandThemeToggle = ({ id, lockScroll = false }: BrandThemeToggleProps) => 
         setIsOpen(false);
       }
     };
-
-    const handleResize = () => updatePos();
-
     document.addEventListener('mousedown', handleMouseDown);
-    window.addEventListener('resize', handleResize);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen, triggerRef]);
 
-    return () => {
-      document.removeEventListener('mousedown', handleMouseDown);
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [isOpen, updatePos]);
+  const currentPreset = BRAND_PRESETS.find((p) => p.id === brand) ?? BRAND_PRESETS[0];
+  const BrandIcon = currentPreset.icon;
+  const isDark = theme === 'dark';
 
   const handleTrigger = () => {
     if (!hasInteracted) setHasInteracted(true);
@@ -87,8 +54,8 @@ const BrandThemeToggle = ({ id, lockScroll = false }: BrandThemeToggleProps) => 
     if (theme !== target) toggleTheme();
   };
 
-  const handleBrandSelect = (id: string) => {
-    setBrand(id as typeof brand);
+  const handleBrandSelect = (brandId: string) => {
+    setBrand(brandId as typeof brand);
     setIsOpen(false);
   };
 
@@ -137,8 +104,10 @@ const BrandThemeToggle = ({ id, lockScroll = false }: BrandThemeToggleProps) => 
             aria-label="Brand and theme settings"
             className={styles.brandThemeToggleDropdown}
             style={{
-              top: dropdownPos?.top ?? 0,
+              top: dropdownPos?.top ?? 'auto',
+              bottom: dropdownPos?.bottom ?? 'auto',
               right: dropdownPos?.right ?? 0,
+              maxHeight: dropdownPos?.maxHeight,
               visibility: dropdownPos ? undefined : 'hidden',
             }}
           >

--- a/src/components/ui/BrandThemeToggle/BrandThemeToggle.tsx
+++ b/src/components/ui/BrandThemeToggle/BrandThemeToggle.tsx
@@ -10,9 +10,11 @@ import styles from './BrandThemeToggle.module.css';
 interface BrandThemeToggleProps {
   /** Unique id for the trigger button */
   id: string;
+  /** Lock page scroll while the dropdown is open. Use when the trigger is not in a fixed-position container. */
+  lockScroll?: boolean;
 }
 
-const BrandThemeToggle = ({ id }: BrandThemeToggleProps) => {
+const BrandThemeToggle = ({ id, lockScroll = false }: BrandThemeToggleProps) => {
   const { brand, setBrand } = useBrand();
   const { theme, toggleTheme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
@@ -40,6 +42,18 @@ const BrandThemeToggle = ({ id }: BrandThemeToggleProps) => {
 
   const handleEscape = useCallback(() => setIsOpen(false), []);
   useFocusTrap(dropdownRef, { isActive: isOpen, onEscape: handleEscape });
+
+  useEffect(() => {
+    if (!lockScroll) return;
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, lockScroll]);
 
   useEffect(() => {
     if (!isOpen) return undefined;

--- a/src/hooks/useFloatingPosition.ts
+++ b/src/hooks/useFloatingPosition.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+type FloatingPos = {
+  top?: number;
+  bottom?: number;
+  right: number;
+  maxHeight: number;
+} | null;
+
+/**
+ * Computes a viewport-aware fixed position for a floating element (dropdown, tooltip, etc.)
+ * anchored to a trigger element. Flips above the trigger when space below is insufficient.
+ * Constrains height to the available space in the chosen direction.
+ *
+ * Uses `visualViewport` for accurate measurements on mobile (accounts for software keyboard
+ * and browser chrome). Falls back to `window.innerHeight` where unavailable.
+ */
+export function useFloatingPosition<T extends HTMLElement = HTMLButtonElement>(isOpen: boolean) {
+  const triggerRef = useRef<T>(null);
+  const [pos, setPos] = useState<FloatingPos>(null);
+
+  const updatePos = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const gap = 8;
+    const safetyMargin = 8;
+
+    const availableBelow = viewportHeight - rect.bottom - gap - safetyMargin;
+    const availableAbove = rect.top - gap - safetyMargin;
+    const placeBelow = availableBelow >= availableAbove;
+
+    if (placeBelow) {
+      setPos({
+        top: rect.bottom + gap,
+        right: window.innerWidth - rect.right,
+        maxHeight: Math.max(availableBelow, 0),
+      });
+    } else {
+      setPos({
+        bottom: viewportHeight - rect.top + gap,
+        right: window.innerWidth - rect.right,
+        maxHeight: Math.max(availableAbove, 0),
+      });
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isOpen) updatePos();
+  }, [isOpen, updatePos]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const vv = window.visualViewport;
+    window.addEventListener('resize', updatePos);
+    vv?.addEventListener('resize', updatePos);
+    return () => {
+      window.removeEventListener('resize', updatePos);
+      vv?.removeEventListener('resize', updatePos);
+    };
+  }, [isOpen, updatePos]);
+
+  return { triggerRef, dropdownPos: pos };
+}

--- a/src/pages/theming-build-notes/sections/PlaygroundSection.tsx
+++ b/src/pages/theming-build-notes/sections/PlaygroundSection.tsx
@@ -94,7 +94,7 @@ const PlaygroundSection = () => {
           </p>
           <div className={styles.flowThemeRow}>
             <p className={styles.flowHierarchy}>Revised trace flow: COMP → SEM → BRAND → PR</p>
-            <BrandThemeToggle id="playground-brand-theme-toggle" />
+            <BrandThemeToggle id="playground-brand-theme-toggle" lockScroll />
           </div>
 
           <div className={styles.demoShowcase}>


### PR DESCRIPTION
## Summary
The `BrandThemeToggle` dropdown has a focus trap feature for keyboard navigation. However, when used within a page there are two UX issues:
- Scrolling is allowed when the dropdown is open which causes the dropdown to be detached from the trigger
- When the dropdown closes, it focus back to the trigger disorienting the users when they have already scrolled away

### Key changes
- Add `lockScroll` into `BrandThemeToggle`
- Enable it in the page use case

The header instance is unaffected (`lockScroll` defaults to false). Since the trigger can't scroll out of view while the dropdown is open.