### PR TITLE
perf: implement route-based code splitting and vendor chunking

### DIFF
--- a/cypress/e2e/portfolio.cy.ts
+++ b/cypress/e2e/portfolio.cy.ts
@@ -10,8 +10,9 @@ describe('Portfolio E2E Tests', () => {
       it('should capture homepage at multiple viewports', () => {
         cy.visit('/');
 
-        // Ensure the main navigation landmark is present before snapping
+        // Ensure the main navigation landmark & lazy-loaded home page is present before snapping
         cy.findByRole('navigation', { name: /main menu/i }).should('be.visible');
+        cy.findByRole('heading', { level: 1, name: /Building product interfaces/i }).should('be.visible');
         cy.percySnapshot('Homepage', { widths });
       });
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { BrowserRouter, HashRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, HashRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/react"
 import Layout from '@/components/layout/Layout';
@@ -15,6 +15,26 @@ const DesignSystemBuildNotes = lazy(() => import('@pages/design-system-build-not
 const YieldFlowCaseStudy = lazy(() => import('@pages/yield-flow-case-study/YieldFlowCaseStudy'));
 const ThemingBuildNotes = lazy(() => import('@pages/theming-build-notes/ThemingBuildNotes'));
 
+// Must live inside Router to call useLocation().
+// key={location.key} forces a new Suspense instance on each navigation,
+// bypassing React 18's startTransition "keep old UI" behavior so PageLoader shows.
+const AppRoutes = () => {
+  const { key } = useLocation();
+  return (
+    <Suspense key={key} fallback={<PageLoader />}>
+      <Routes>
+        <Route path={ROUTES.HOME} element={<Home />} />
+        <Route path={ROUTES.LABS} element={<Labs />} />
+        <Route path={ROUTES.DESIGN_SYSTEM_BUILD_NOTES} element={<DesignSystemBuildNotes />} />
+        <Route path={ROUTES.SYSTEM_CORE} element={<SystemCore />} />
+        <Route path={ROUTES.YIELD_FLOW_CASE_STUDY} element={<YieldFlowCaseStudy />} />
+        <Route path={ROUTES.THEMING_BUILD_NOTES} element={<ThemingBuildNotes />} />
+        <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
+      </Routes>
+    </Suspense>
+  );
+};
+
 const App = () => {
   // TODO: Remove HashRouter shim once fully migrated from GitHub Pages to Vercel.
   // GitHub Pages requires HashRouter for deep-linking; Vercel uses BrowserRouter with rewrites.
@@ -25,18 +45,8 @@ const App = () => {
   return (
     <Router>
       <Layout>
-        {/* Suspense inside Layout so Header/Footer stay visible during route transitions. */}
-        <Suspense fallback={<PageLoader />}>
-          <Routes>
-            <Route path={ROUTES.HOME} element={<Home />} />
-            <Route path={ROUTES.LABS} element={<Labs />} />
-            <Route path={ROUTES.DESIGN_SYSTEM_BUILD_NOTES} element={<DesignSystemBuildNotes />} />
-            <Route path={ROUTES.SYSTEM_CORE} element={<SystemCore />} />
-            <Route path={ROUTES.YIELD_FLOW_CASE_STUDY} element={<YieldFlowCaseStudy />} />
-            <Route path={ROUTES.THEMING_BUILD_NOTES} element={<ThemingBuildNotes />} />
-            <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
-          </Routes>
-        </Suspense>
+        {/* AppRoutes uses useLocation() to key the Suspense boundary per navigation. */}
+        <AppRoutes />
       </Layout>
       <Analytics />
       <SpeedInsights />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/react"
 import Layout from '@/components/layout/Layout';
-import Home from '@pages/home/Home';
-import Labs from '@pages/labs/Labs';
-import SystemCore from '@pages/system-core/SystemCore';
-import DesignSystemBuildNotes from '@pages/design-system-build-notes/DesignSystemBuildNotes';
-import YieldFlowCaseStudy from '@pages/yield-flow-case-study/YieldFlowCaseStudy';
-import ThemingBuildNotes from '@pages/theming-build-notes/ThemingBuildNotes';
+import PageLoader from '@/components/ui/PageLoader/PageLoader';
 import { ROUTES } from '@constants/routes';
+
+// Route-level code splitting: each page is a separate JS chunk downloaded on demand.
+// Vite creates one output file per dynamic import; the browser fetches it only on first navigation.
+const Home = lazy(() => import('@pages/home/Home'));
+const Labs = lazy(() => import('@pages/labs/Labs'));
+const SystemCore = lazy(() => import('@pages/system-core/SystemCore'));
+const DesignSystemBuildNotes = lazy(() => import('@pages/design-system-build-notes/DesignSystemBuildNotes'));
+const YieldFlowCaseStudy = lazy(() => import('@pages/yield-flow-case-study/YieldFlowCaseStudy'));
+const ThemingBuildNotes = lazy(() => import('@pages/theming-build-notes/ThemingBuildNotes'));
 
 const App = () => {
   // TODO: Remove HashRouter shim once fully migrated from GitHub Pages to Vercel.
@@ -20,15 +25,18 @@ const App = () => {
   return (
     <Router>
       <Layout>
-        <Routes>
-          <Route path={ROUTES.HOME} element={<Home />} />
-          <Route path={ROUTES.LABS} element={<Labs />} />
-          <Route path={ROUTES.DESIGN_SYSTEM_BUILD_NOTES} element={<DesignSystemBuildNotes />} />
-          <Route path={ROUTES.SYSTEM_CORE} element={<SystemCore />} />
-          <Route path={ROUTES.YIELD_FLOW_CASE_STUDY} element={<YieldFlowCaseStudy />} />
-          <Route path={ROUTES.THEMING_BUILD_NOTES} element={<ThemingBuildNotes />} />
-          <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
-        </Routes>
+        {/* Suspense inside Layout so Header/Footer stay visible during route transitions. */}
+        <Suspense fallback={<PageLoader />}>
+          <Routes>
+            <Route path={ROUTES.HOME} element={<Home />} />
+            <Route path={ROUTES.LABS} element={<Labs />} />
+            <Route path={ROUTES.DESIGN_SYSTEM_BUILD_NOTES} element={<DesignSystemBuildNotes />} />
+            <Route path={ROUTES.SYSTEM_CORE} element={<SystemCore />} />
+            <Route path={ROUTES.YIELD_FLOW_CASE_STUDY} element={<YieldFlowCaseStudy />} />
+            <Route path={ROUTES.THEMING_BUILD_NOTES} element={<ThemingBuildNotes />} />
+            <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
+          </Routes>
+        </Suspense>
       </Layout>
       <Analytics />
       <SpeedInsights />

--- a/src/components/oklch/OklchInteractiveAnchor.module.css
+++ b/src/components/oklch/OklchInteractiveAnchor.module.css
@@ -213,18 +213,6 @@
   box-shadow: var(--sem-elevation-medium);
 }
 
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
 /* 05. Responsive Upgrades */
 
 /* Tablet: Value returns to right side */

--- a/src/components/oklch/OklchInteractiveAnchor.tsx
+++ b/src/components/oklch/OklchInteractiveAnchor.tsx
@@ -60,7 +60,7 @@ const OklchInteractiveAnchor = () => {
                 aria-describedby={`${lightnessId}-desc`}
               />
             </div>
-            <span id={`${lightnessId}-desc`} className={styles.srOnly}>
+            <span id={`${lightnessId}-desc`} className="srOnly">
               Changes how bright the color appears.
             </span>
           </div>
@@ -94,7 +94,7 @@ const OklchInteractiveAnchor = () => {
                 aria-describedby={`${chromaId}-desc`}
               />
             </div>
-            <span id={`${chromaId}-desc`} className={styles.srOnly}>
+            <span id={`${chromaId}-desc`} className="srOnly">
               Changes how saturated the color feels.
             </span>
           </div>
@@ -128,7 +128,7 @@ const OklchInteractiveAnchor = () => {
                 aria-describedby={`${hueId}-desc`}
               />
             </div>
-            <span id={`${hueId}-desc`} className={styles.srOnly}>
+            <span id={`${hueId}-desc`} className="srOnly">
               Changes which hue the color appears to be.
             </span>
           </div>

--- a/src/components/ui/PageLoader/PageLoader.module.css
+++ b/src/components/ui/PageLoader/PageLoader.module.css
@@ -1,23 +1,12 @@
 .pageLoader {
+  min-height: 100vh;
+  padding-top: var(--pr-spacing-16);
+}
+
+.pageLoaderContent {
+  padding-top: var(--pr-spacing-21);
+  max-width: var(--sem-layout-page-max);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: calc(100vh - var(--sem-layout-header-height));
-  padding: var(--pr-spacing-11);
-}
-
-.pageLoaderSpinner {
-  display: block;
-  width: var(--pr-size-32);
-  height: var(--pr-size-32);
-  border: var(--pr-border-width-2) solid var(--sem-color-border-subtle);
-  border-top-color: var(--sem-color-accent-base);
-  border-radius: var(--sem-radius-pill);
-  animation: spin var(--pr-duration-slow) linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+  flex-direction: column;
+  gap: var(--pr-spacing-4);
 }

--- a/src/components/ui/PageLoader/PageLoader.module.css
+++ b/src/components/ui/PageLoader/PageLoader.module.css
@@ -1,0 +1,23 @@
+.pageLoader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - var(--sem-layout-header-height));
+  padding: var(--pr-spacing-11);
+}
+
+.pageLoaderSpinner {
+  display: block;
+  width: var(--pr-size-32);
+  height: var(--pr-size-32);
+  border: var(--pr-border-width-2) solid var(--sem-color-border-subtle);
+  border-top-color: var(--sem-color-accent-base);
+  border-radius: var(--sem-radius-pill);
+  animation: spin var(--pr-duration-slow) linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/ui/PageLoader/PageLoader.tsx
+++ b/src/components/ui/PageLoader/PageLoader.tsx
@@ -1,9 +1,15 @@
+import Container from '@/components/layout/Container';
+import Skeleton from '@/components/ui/Skeleton/Skeleton';
 import styles from './PageLoader.module.css';
 
 const PageLoader = () => (
   <div className={styles.pageLoader} role="status" aria-label="Loading page">
-    <span className={styles.pageLoaderSpinner} aria-hidden="true" />
-    <span className="srOnly">Loading…</span>
+    <Container className={styles.pageLoaderContent} variant="wide">
+      <Skeleton width={160} height={18} />
+      <Skeleton width={360} height={64} />
+      <Skeleton width={720} height={148} />
+      <span className="srOnly">Loading…</span>
+    </Container>
   </div>
 );
 

--- a/src/components/ui/PageLoader/PageLoader.tsx
+++ b/src/components/ui/PageLoader/PageLoader.tsx
@@ -1,0 +1,10 @@
+import styles from './PageLoader.module.css';
+
+const PageLoader = () => (
+  <div className={styles.pageLoader} role="status" aria-label="Loading page">
+    <span className={styles.pageLoaderSpinner} aria-hidden="true" />
+    <span className="srOnly">Loading…</span>
+  </div>
+);
+
+export default PageLoader;

--- a/src/components/ui/Skeleton/Skeleton.module.css
+++ b/src/components/ui/Skeleton/Skeleton.module.css
@@ -1,0 +1,12 @@
+.skeleton {
+  display: block;
+  border-radius: var(--sem-radius-lg);
+  background-color: var(--sem-color-bg-striped);
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,27 @@
+import styles from './Skeleton.module.css';
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+}
+
+const Skeleton = ({
+  width = '100%',
+  height = '1rem',
+}: SkeletonProps) => {
+  const style: React.CSSProperties = {
+    maxWidth: width,
+    height,
+  };
+
+  return (
+    <div
+      className={styles.skeleton}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+};
+
+export default Skeleton;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,19 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, 'index.html'),
       },
+      output: {
+        // Vendor chunks: stable filenames that browsers cache between deployments.
+        // A version bump to one library only busts that library's chunk, not all vendor code.
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-router': ['react-router-dom'],
+          'vendor-icons': ['lucide-react'],
+          // prism-react-renderer is only used in labs pages (ThemingBuildNotes,
+          // DesignSystemBuildNotes). After route splitting, it will only download
+          // when a user first navigates to one of those routes.
+          'vendor-prism': ['prism-react-renderer'],
+        },
+      },
     },
   },
   server: {


### PR DESCRIPTION
## Overview
This PR optimizes the initial bundle size by transitioning from a single monolithic `main.js` to a code-split architecture using `React.lazy` and Vite's `manualChunks`.

### Changes
- **Route Splitting:** Converted static page imports to dynamic `lazy()` imports in `App.tsx`.
- **Loading State:** Added `PageLoader` component with `<Suspense>` boundary to handle chunk loading states.
- **Vendor Optimization:** Configured `vite.config.ts` to isolate stable libraries (`react`, `router`, `icons`, `prism`) into separate, cache-friendly chunks.

### Performance Impact (Expected)
- **Initial Load:** Reduction of ~30-40kB (gzipped) by deferring prism-react-renderer and off-screen route code.
- **Caching:** High-frequency UI updates will no longer bust the cache for heavy vendor libraries.
- **Lighthouse:** Improved "Time to Interactive" and "Total Blocking Time."

## Verification 

### Dev
- [x] Bundle analysis: `npx vite-bundle-visualizer`
  - [x] Confirm main.js contains only: React, ReactDOM, react-router-dom, Layout, contexts
  - [x] All page modules and prism-react-renderer should be in separate chunks.

| BEFORE | AFTER |
| --- | --- |
| <img width="400" height="826" alt="Screenshot 2026-03-18 at 2 48 30 PM" src="https://github.com/user-attachments/assets/d756454e-8f71-4a6d-8b30-389a89bf3850" /> | <img width="400" height="826" alt="Screenshot 2026-03-18 at 3 46 07 PM" src="https://github.com/user-attachments/assets/44635765-687a-489e-b6ac-ed24ef345b7f" /> |


- [x] Dev mode: `npm run dev`
  - Navigate to each route, confirm no console errors, pages render correctly

- [x] Preview mode
  - Tests the actual built output; open DevTools Network tab and confirm each route loads its own chunk file

### Prod
- [x] Hash routing: test manually to confirm GitHub Pages behavior is unaffected