### PR TITLE
fix: conditionally render vercel analytics and speed insights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,8 +48,8 @@ const App = () => {
         {/* AppRoutes uses useLocation() to key the Suspense boundary per navigation. */}
         <AppRoutes />
       </Layout>
-      <Analytics />
-      <SpeedInsights />
+      {!isGitHubPages && <Analytics />}
+      {!isGitHubPages && <SpeedInsights />}
     </Router>
   );
 };


### PR DESCRIPTION
## Overview
The site is deployed to both Vercel and GitHub Pages. `<Analytics />` and `<SpeedInsights />` from `@vercel/analytics` and `@vercel/speed-insights` are unconditionally rendered, causing errors on the GitHub Pages deployment.

This simply skips the components when running on GitHub Pages.

### Testing
- [x] Analytics (`vitals` and `view`) are still being fired in Vercel Preview when navigating between routes